### PR TITLE
Add activity feed API

### DIFF
--- a/public/graphite-demo/server.js
+++ b/public/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a simple Express server for the Graphite demo with a mock activity feed endpoint.

### What changed?

Created a new server.js file in the public/graphite-demo directory that:
- Sets up a basic Express server running on port 3000
- Defines a mock activity feed with 3 sample entries
- Implements a GET endpoint at `/feed` that returns the activity feed data as JSON

### How to test?

1. Navigate to the graphite-demo directory
2. Run `npm install express` (if not already installed)
3. Start the server with `node server.js`
4. Make a GET request to `http://localhost:3000/feed`
5. Verify that the response contains the mock activity feed data

### Why make this change?

This server provides a backend API for the Graphite demo application, allowing frontend components to fetch activity feed data. The mock data enables development and testing of the frontend without requiring a full backend implementation.